### PR TITLE
Fix IsNotNullOrEmpty String Extension

### DIFF
--- a/lib/extensions/string_extensions.dart
+++ b/lib/extensions/string_extensions.dart
@@ -5,7 +5,7 @@ extension StringExNullable on String? {
 
   bool get isNullOrBlank => this == null || this!.isEmpty || this!.trim().isEmpty;
 
-  bool get isNotNullOrEmpty => this == null || this!.isNotEmpty;
+  bool get isNotNullOrEmpty => !isNullOrEmpty;
 }
 
 extension StringEx on String {


### PR DESCRIPTION
Just a minor fix of the extension. We have `isNotNullOrEmpty` extension that is, by the idea, a negation of `isNullOrEmpty`. In the current implementation though it works like `is null or not empty`. By using `!isNullOrEmpty` we transform it to `is not null and not empty`.