### PR TITLE
NStack pubspec Reference

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -444,7 +444,7 @@ packages:
       resolved-ref: "46809853dae97f77c252de05de49ad03b12c23a7"
       url: "https://github.com/nstack-io/flutter-sdk.git"
     source: git
-    version: "0.2.5"
+    version: "0.5.1"
   package_config:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -441,8 +441,8 @@ packages:
     description:
       path: "."
       ref: HEAD
-      resolved-ref: bf246c268d0403aef0f06bc271bdd0f049c73c51
-      url: "git://github.com/nstack-io/flutter-sdk.git"
+      resolved-ref: "46809853dae97f77c252de05de49ad03b12c23a7"
+      url: "https://github.com/nstack-io/flutter-sdk.git"
     source: git
     version: "0.2.5"
   package_config:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   flutter_svg: ^0.23.0+1
   nstack:
     git:
-      url: git://github.com/nstack-io/flutter-sdk.git
+      url: https://github.com/nstack-io/flutter-sdk.git
       #ref: v0.2.5
 
   # Net


### PR DESCRIPTION
Including the NStack package from git with the link starting with `git://` causes `flutter pub get` to fall. There have been several reports in Slack channel recently and I have also faced this problem. This PR changes `pubspec.yaml` to use the NStack link starting with `https://` which actually resolves the problem.