### PR TITLE
chore: Linter updates: Void-Async

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -25,6 +25,7 @@ linter:
     - avoid_types_as_parameter_names
     - avoid_unnecessary_containers
     - avoid_unused_constructor_parameters
+    - avoid_void_async
     - await_only_futures
     - camel_case_extensions
     - curly_braces_in_flow_control_structures

--- a/lib/data/interceptor/meta_interceptor.dart
+++ b/lib/data/interceptor/meta_interceptor.dart
@@ -12,8 +12,10 @@ class MetaInterceptor extends InterceptorsWrapper {
   final AppFlavor flavor;
 
   @override
-  void onRequest(
-      RequestOptions options, RequestInterceptorHandler handler) async {
+  Future<void> onRequest(
+    RequestOptions options,
+    RequestInterceptorHandler handler,
+  ) async {
     if (options.headers['Accept'] == null) {
       options.headers['Accept'] = 'application/json; charset=UTF-8';
     }

--- a/lib/main_common.dart
+++ b/lib/main_common.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_template/injection/dependencies.dart';
 import 'package:flutter_template/presentation/app.dart';
+
 import 'presentation/app_flavor.dart';
 
+// ignore: avoid_void_async
 void mainCommon(AppFlavor flavor) async {
   WidgetsFlutterBinding.ensureInitialized();
   await DependencyManager.inject(flavor);

--- a/lib/presentation/feature/profile/profile_cubit.dart
+++ b/lib/presentation/feature/profile/profile_cubit.dart
@@ -13,11 +13,12 @@ class ProfileCubit extends Cubit<ProfileState> {
     @factoryParam ProfileState? state,
   }) : super(state ?? ProfileState.initial());
 
-  void load() async {
+  Future<void> load() async {
     if (state.isLoading) return;
 
     emit(state.copyWith(isLoading: true));
-    await profileService
+
+    return profileService
         .getProfileName()
         .then(
           (value) => emit(


### PR DESCRIPTION
So instead of having this:

```dart
void something() async {
  final variable = 0;
  ...
  await future();
}
```

We will have:
```dart
Future<void> something() {
  final variable = 0;
  ...
  return future();
}
```

It's good overall, but it also optimises the future's work in the new [Dart 2.18 version](https://github.com/dart-lang/sdk/blob/master/CHANGELOG.md#dart-vm).